### PR TITLE
[feat] 이메일 인증 코드 검증 로직 추가

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { emailService } from "../services/email.service";
 
+// 이메일 검증 코드 전송
 export const sendVerificationCode = async (
   req: Request,
   res: Response
@@ -45,6 +46,101 @@ export const sendVerificationCode = async (
     // TODO : 에러 타입 지정 및 핸들러 추가
     // 임시로 any 타입 지정
     console.error("인증 코드 발송 실패:", error);
+    if (error.code && error.statusCode) {
+      return res.status(error.statusCode).json({
+        success: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.field && { field: error.field }),
+        },
+      });
+    }
+    return res.status(500).json({
+      success: false,
+      error: {
+        code: "INTERNAL_SERVER_ERROR",
+        message: "서버 오류가 발생했습니다.",
+      },
+    });
+  }
+};
+
+export const verifyCode = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  try {
+    const { email, code } = req.body;
+
+    // 이메일 필수 체크
+    if (!email) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "이메일 주소가 누락되었습니다.",
+          field: "email",
+        },
+      });
+    }
+
+    // 이메일 형식 체크
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "INVALID_EMAIL_FORMAT",
+          message: "올바른 이메일 형식이 아닙니다.",
+          field: "email",
+        },
+      });
+    }
+
+    // 인증 코드 존재 여부 체크
+    if (!code) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "인증 코드가 누락되었습니다.",
+          field: "code",
+        },
+      });
+    }
+
+    // 인증 코드 형식 체크 (6자리 숫자)
+    if (!/^\d{6}$/.test(code)) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "INVALID_CODE_FORMAT",
+          message: "인증 코드는 6자리 숫자여야 합니다.",
+          field: "code",
+        },
+      });
+    }
+
+    const result = await emailService.verifyCode(email, code);
+
+    if (!result) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: "VERIFICATION_FAILED",
+          message:
+            "인증에 실패했습니다. 인증 코드가 올바르지 않거나 만료되었습니다.",
+        },
+      });
+    }
+
+    return res.status(200).json({
+      success: result,
+      message: "이메일 인증이 완료되었습니다.",
+    });
+  } catch (error: any) {
+    console.error("이메일 인증 실패:", error);
     if (error.code && error.statusCode) {
       return res.status(error.statusCode).json({
         success: false,

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,9 +1,14 @@
 import { Router } from "express";
-import { sendVerificationCode } from "../controllers/auth.controller";
+import {
+  sendVerificationCode,
+  verifyCode,
+} from "../controllers/auth.controller";
 
 const router = Router();
 
 // 이메일 인증 코드 발송
-router.post("/sendEmailVerification", sendVerificationCode);
+router.post("/email-verifications", sendVerificationCode);
+// 이메일 인증 코드 검증
+router.post("/email-verifications/verify", verifyCode);
 
 export default router;

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -12,6 +12,11 @@ interface SendVerificationCodeResult {
 // TODO : Redis
 
 class EmailService {
+  /**
+   * 회원가입 시 기입한 이메일에 인증번호 전송
+   * @param email
+   * @returns
+   */
   async sendVerificationCode(
     email: string
   ): Promise<SendVerificationCodeResult> {
@@ -45,27 +50,36 @@ class EmailService {
   }
 
   /**
-   * 인증 코드 검증
+   * 이메일 인증번호가 DB와 일치하는지 검증
+   * @param email
+   * @param code
+   * @returns
    */
-  //   async verifyCode(email: string, code: string): Promise<boolean> {
-  //     const verification = await EmailVerification.findOne({
-  //       where: { email, code },
-  //     });
+  async verifyCode(email: string, code: string): Promise<boolean> {
+    const verification = await EmailVerification.findOne({
+      where: { email, code },
+    });
 
-  //     if (!verification) {
-  //       return false;
-  //     }
+    // 검증 실패 : 값이 없음
+    if (!verification) {
+      return false;
+    }
 
-  //     // 만료 시간 확인
-  //     if (new Date() > verification.expiresAt) {
-  //       await verification.destroy();
-  //       return false;
-  //     }
+    // 검증 실패 : 코드 시간 만료됨
+    if (new Date() > verification.expiresAt) {
+      await verification.destroy();
+      return false;
+    }
 
-  //     // 인증 성공 시 삭제
-  //     await verification.destroy();
-  //     return true;
-  //   }
+    // 검증 실패: 코드가 일치하지 않음
+    if (verification.code !== code) {
+      return false;
+    }
+
+    // 검증 성공 -> DB 삭제
+    await verification.destroy();
+    return true;
+  }
 }
 
 export const emailService = new EmailService();


### PR DESCRIPTION
# 🚀요약
이메일 인증 코드 검증 로직 추가

# 📝작업 내용

- /email-verifications/verify 엔드포인트 추가
- 이메일 인증코드 검증 로직 구현
- 성공/실패 응답 처리

## 현재 문제점
- Controller에 validation 로직과 비즈니스 로직이 섞여 있음
- Service에서 boolean으로 false 경우를 반환하기 때문에 어떤 이유로 인증에 실패했는지 캐치할 수 없음
- 에러 처리 코드 중복됨

## 개선 방안
1. Custom Error 클래스 정의
2. Service에서 에러 던지기
3. 글로벌 에러 핸들러 미들웨어 추가
4. Validation을 미들웨어 분리 [선택]

## 참고 파일
- `controllers/auth.controller.ts`
- `services/email.service.ts`

## 계획
회원 등록 (sign-in)까지 작업한 이후 리팩토링 진행