### PR TITLE
[design] 캘린더 내부의 날짜 셀의 세로 크기가 일정하지 않은 문제 수정

### DIFF
--- a/frontend/src/components/calendar/CalendarDayCell.tsx
+++ b/frontend/src/components/calendar/CalendarDayCell.tsx
@@ -12,6 +12,10 @@ interface CalendarDayCellProps {
     onEventClick: (eventId: number) => void;
 }
 
+// 이벤트 티켓 높이와 간격 상수
+const EVENT_TICKET_HEIGHT = 20; // px
+const EVENT_GAP = 2; // px (0.125rem = 2px)
+
 export const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
     day,
     events,
@@ -22,9 +26,62 @@ export const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
     const dayOfWeek = day.date.getDay();
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
     const dateKey = CalendarUtils.getDateKey(day.date);
+    const cellRef = React.useRef<HTMLDivElement>(null);
+    const eventsGridRef = React.useRef<HTMLDivElement>(null);
+    const [maxVisibleEvents, setMaxVisibleEvents] = React.useState(4);
+
+    // 리사이즈 감지 및 최대 표시 가능한 이벤트 개수 계산
+    React.useEffect(() => {
+        const calculateMaxEvents = () => {
+            if (!eventsGridRef.current) return;
+
+            const gridElement = eventsGridRef.current;
+            const availableHeight = gridElement.clientHeight;
+
+            // 사용 가능한 높이에서 표시할 수 있는 이벤트 개수 계산
+            // 각 이벤트는 높이 20px + 간격 2px = 22px 필요
+            const eventHeightWithGap = EVENT_TICKET_HEIGHT + EVENT_GAP;
+            const calculatedMax = Math.max(
+                1,
+                Math.floor(availableHeight / eventHeightWithGap),
+            );
+
+            setMaxVisibleEvents(calculatedMax);
+        };
+
+        // 초기 계산 (약간의 지연을 두어 레이아웃이 완료된 후 계산)
+        const timeoutId = setTimeout(calculateMaxEvents, 0);
+
+        // ResizeObserver를 사용하여 리사이즈 감지
+        // 부모 셀 요소를 관찰하여 셀 크기 변경 감지
+        const resizeObserver = new ResizeObserver(() => {
+            calculateMaxEvents();
+        });
+
+        if (cellRef.current) {
+            resizeObserver.observe(cellRef.current);
+        }
+
+        // 창 리사이즈 이벤트도 감지 (추가 보장)
+        window.addEventListener('resize', calculateMaxEvents);
+
+        return () => {
+            clearTimeout(timeoutId);
+            resizeObserver.disconnect();
+            window.removeEventListener('resize', calculateMaxEvents);
+        };
+    }, []);
+
+    // 최대 개수만큼만 이벤트 필터링
+    const visibleEvents = React.useMemo(() => {
+        // row 순서대로 정렬하여 위에서부터 표시
+        const sortedEvents = [...events].sort((a, b) => a.row - b.row);
+        return sortedEvents.slice(0, maxVisibleEvents);
+    }, [events, maxVisibleEvents]);
 
     return (
         <div
+            ref={cellRef}
             className={`calendar-day-cell ${
                 isWeekend ? 'calendar-day-cell-weekend' : ''
             }`}
@@ -36,8 +93,8 @@ export const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
             >
                 {day.dayOfMonth}
             </div>
-            <div className="calendar-events-grid">
-                {events.map((eventLayout) => (
+            <div ref={eventsGridRef} className="calendar-events-grid">
+                {visibleEvents.map((eventLayout) => (
                     <MonthEventTicket
                         key={`${eventLayout.event.id}-${dateKey}`}
                         id={eventLayout.event.id}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -34,7 +34,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
     return (
         <aside
-            className={`${widthMap[width]} shrink-0 ${borderMap[borderPosition]} border-gray-200 bg-white`}
+            className={`${widthMap[width]} shrink-0 ${borderMap[borderPosition]} border-gray-200 bg-stone-100`}
         >
             <div className="flex h-full flex-col p-4">
                 <div className="mb-4 flex items-center justify-between">

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -539,6 +539,8 @@
             7,
             minmax(0, 1fr)
         ); /* 일~토 7개 열 균등 분배 */
+        grid-auto-rows: 1fr; /* 모든 행의 높이를 동일하게 설정 */
+        min-height: 0; /* 그리드 아이템이 올바르게 축소되도록 */
     }
 
     /* 날짜 셀: 각 날짜를 표시하는 기본 스타일 */
@@ -547,6 +549,8 @@
         z-index: 0; /* border가 뒤에 오도록 */
         min-height: 0; /* flex/grid 아이템의 최소 높이 제한 해제 */
         height: 100%; /* 부모의 높이를 모두 차지 */
+        display: flex; /* flex 레이아웃으로 변경 */
+        flex-direction: column; /* 세로 방향 배치 */
         border-width: 0.5px;
         border-color: var(--color-stone-100);
     }
@@ -577,13 +581,11 @@
         z-index: 1; /* 티켓이 border 위에 표시되도록 */
         display: grid;
         flex: 1 1 0%; /* 날짜 숫자 아래 남은 공간을 모두 차지 */
+        min-height: 0; /* flex 아이템이 올바르게 축소되도록 */
         grid-template-columns: 100%;
-        grid-auto-rows: minmax(
-            14px,
-            1fr
-        ); /* 각 이벤트 행의 최소 높이 14px, 최대는 남은 공간만큼 */
+        grid-auto-rows: 20px; /* 각 이벤트 행의 고정 높이 (20px 티켓 높이) */
         align-content: start; /* 이벤트들을 위쪽부터 배치 */
-        gap: 0.125rem; /* 이벤트 간 간격 */
+        gap: 0.125rem; /* 이벤트 간 간격 (2px) */
         overflow: hidden; /* 넘치는 이벤트는 숨김 */
     }
 


### PR DESCRIPTION
## 요약
 캘린더 내부의 날짜 셀의 세로 크기가 일정하지 않은 문제 수정

## 작업 내용
- grid-auto-rows: 1fr 추가 → 모든 행 높이 동일화
- min-height: 0 추가 → 그리드 아이템 축소 동작 보장
- 동적 이벤트 개수 계산 로직 추가

## 테스트 포인트
- 이벤트가 없는 날짜 셀도 다른 셀과 높이가 동일한지 확인
- 창 높이를 줄일 때 모든 셀이 동일하게 축소되는지 확인
- 표시되는 이벤트 개수가 공간에 맞게 조절되는지 확인
- 최소 1개는 항상 표시되는지 확인